### PR TITLE
Add torch compile row to Pytorch Install table

### DIFF
--- a/_includes/quick-start-module.js
+++ b/_includes/quick-start-module.js
@@ -182,72 +182,88 @@ function getIDFromBackend(backend) {
       tensorrt: 'tensorrt',
       tvm: 'tvm',
     };
-    return idTobackendMap[backend]
+    return idTobackendMap[backend];
+}
+
+function getPmCmd(backend) {
+    const pmCmd = {
+        onnxrt: 'onnxruntime',
+        tvm: 'apache-tvm',
+        openvino: 'openvino',
+        tensorrt: 'torch-tensorrt',
+    };
+    return pmCmd[backend];
+}
+
+function getImportCmd(backend) {
+    const importCmd = {
+        onnxrt: 'import onnxruntime',
+        tvm: 'import tvm',
+        openvino: 'import openvino.torch',
+        tensorrt: 'import torch_tensorrt'
+    }
+    return importCmd[backend];
 }
 
 function getInstallCommand(optionID) {
     backend = getIDFromBackend(optionID);
+    pmCmd = getPmCmd(optionID);
     finalCmd = "";
-    pipCmdOV = "pip3 install openvino";
-    condaCmdOV = "conda install openvino";
-    pipCmdOnnx = "pip3 install onnxruntime"
-    condaCmdOnnx = "conda install onnxruntime";
-    if (backend == "openvino") {
-        if (opts.pm == "pip") {
-            finalCmd = pipCmdOV;
-        }
-        else if (opts.pm == "conda") {
-            finalCmd = condaCmdOV;
-        }
-    }
-    if(backend == "onnxrt") {
-        if (opts.pm == "pip") {
-            finalCmd = pipCmdOnnx;
-        }
-        else if (opts.pm == "conda") {
-            finalCmd = condaCmdOnnx;
-        }
-    }
+   if (opts.pm == "pip") {
+        finalCmd = `pip3 install ${pmCmd}`;
+   }
+   else if (opts.pm == "conda") {
+        finalCmd = `conda install ${pmCmd}`;
+   }
     return finalCmd;
 }
 
 function getTorchCompileUsage(optionId) {
     backend = getIDFromBackend(optionId);
-    importCmdOV = "<br>" + "import openvino.torch" + "<br>";
+    importCmd = "<br>" + getImportCmd(optionId) + "<br>";
     finalCmd = "";
     tcUsage = "# Torch Compile usage: ";
     backendCmd = `torch.compile(model, backend="${backend}")`;
-    finalUsageCmd = tcUsage;
-    importCmdOnnx = "<br>" + "import onnxruntime" + "<br>";
+    libtorchCmd = `# Torch compile ${backend} not supported with Libtorch`;
+
+    if (opts.pm == "libtorch") {
+        return libtorchCmd;
+    }
     if (backend == "openvino") {
-        if (opts.pm == "libtorch") {
-            return "# Torch compile openvino not supported with Libtorch";
-        }
         if (opts.pm == "source") {
             finalCmd += "# Follow instructions at this URL to build openvino from source: https://github.com/openvinotoolkit/openvino/blob/master/docs/dev/build.md" + "<br>" ;
-            tcUsage += importCmdOV;
+            tcUsage += importCmd;
         }
         else if (opts.pm == "conda") {
-            tcUsage += importCmdOV;
+            tcUsage += importCmd;
         }
-        if (opts.os == "windows" && !tcUsage.includes(importCmdOV)) {
-            tcUsage += importCmdOV;
+        if (opts.os == "windows" && !tcUsage.includes(importCmd)) {
+            tcUsage += importCmd;
         }
     }
+    else{
+        tcUsage += importCmd;
+    }
     if (backend == "onnxrt") {
-        tcUsage += importCmdOnnx;
-        if (opts.pm == "libtorch") {
-            return "# Torch compile onnxruntime not supported with Libtorch";
-        }
         if (opts.pm == "source") {
             finalCmd += "# Follow instructions at this URL to build onnxruntime from source: https://onnxruntime.ai/docs/build" + "<br>" ;
         }
     }
-    return finalCmd + tcUsage + backendCmd;
+    if (backend == "tvm") {
+        if (opts.pm == "source") {
+            finalCmd += "# Follow instructions at this URL to build tvm from source: https://tvm.apache.org/docs/install/from_source.html" + "<br>" ;
+        }
+    }
+    if (backend == "tensorrt") {
+        if (opts.pm == "source") {
+            finalCmd += "# Follow instructions at this URL to build tensorrt from source: https://pytorch.org/TensorRT/getting_started/installation.html#compiling-from-source" + "<br>" ;
+        }
+    }
+    finalCmd += tcUsage + backendCmd;
+    return finalCmd
 }
-// Add Torch Compile usage instructions as a command note
+
 function addTorchCompileCommandNote(selectedOptionId) {
-    console.log(selectedOptionId);
 
     if (!selectedOptionId) {
         return;
@@ -256,13 +272,12 @@ function addTorchCompileCommandNote(selectedOptionId) {
     $("#command").append(
         `<pre> ${getInstallCommand(selectedOptionId)} </pre>`
     );
-    result = getTorchCompileUsage(selectedOptionId);
     $("#command").append(
-        `<pre> ${result} </pre>`
+        `<pre> ${getTorchCompileUsage(selectedOptionId)} </pre>`
     );
 }
+
 function selectedOption(option, selection, category) {
-   console.log("Surya Option:", option)
   $(option).removeClass("selected");
   $(selection).addClass("selected");
   opts[category] = selection.id;

--- a/_includes/quick-start-module.js
+++ b/_includes/quick-start-module.js
@@ -21,6 +21,7 @@ var opts = {
   pm: 'pip',
   language: 'python',
   ptbuild: 'stable',
+  'torch-compile': null
 };
 
 var supportedCloudPlatforms = [
@@ -34,6 +35,7 @@ var package = $(".package > .option");
 var language = $(".language > .option");
 var cuda = $(".cuda > .option");
 var ptbuild = $(".ptbuild > .option");
+var torchCompile = $(".torch-compile > .option")
 
 os.on("click", function() {
   selectedOption(os, this, "os");
@@ -49,6 +51,9 @@ cuda.on("click", function() {
 });
 ptbuild.on("click", function() {
   selectedOption(ptbuild, this, "ptbuild")
+});
+torchCompile.on("click", function() {
+    selectedOption(torchCompile, this, "torch-compile")
 });
 
 // Pre-select user's operating system
@@ -168,7 +173,96 @@ function changeAccNoneName(osname) {
   }
 }
 
+function getIDFromBackend(backend) {
+    const idTobackendMap = {
+      inductor: 'inductor',
+      cgraphs : 'cudagraphs',
+      onnxrt: 'onnxrt',
+      openvino: 'openvino',
+      tensorrt: 'tensorrt',
+      tvm: 'tvm',
+    };
+    return idTobackendMap[backend]
+}
+
+function getInstallCommand(optionID) {
+    backend = getIDFromBackend(optionID);
+    finalCmd = "";
+    pipCmdOV = "pip3 install openvino";
+    condaCmdOV = "conda install openvino";
+    pipCmdOnnx = "pip3 install onnxruntime"
+    condaCmdOnnx = "conda install onnxruntime";
+    if (backend == "openvino") {
+        if (opts.pm == "pip") {
+            finalCmd = pipCmdOV;
+        }
+        else if (opts.pm == "conda") {
+            finalCmd = condaCmdOV;
+        }
+    }
+    if(backend == "onnxrt") {
+        if (opts.pm == "pip") {
+            finalCmd = pipCmdOnnx;
+        }
+        else if (opts.pm == "conda") {
+            finalCmd = condaCmdOnnx;
+        }
+    }
+    return finalCmd;
+}
+
+function getTorchCompileUsage(optionId) {
+    backend = getIDFromBackend(optionId);
+    importCmdOV = "<br>" + "import openvino.torch" + "<br>";
+    finalCmd = "";
+    tcUsage = "# Torch Compile usage: ";
+    backendCmd = `torch.compile(model, backend="${backend}")`;
+    finalUsageCmd = tcUsage;
+    importCmdOnnx = "<br>" + "import onnxruntime" + "<br>";
+    if (backend == "openvino") {
+        if (opts.pm == "libtorch") {
+            return "# Torch compile openvino not supported with Libtorch";
+        }
+        if (opts.pm == "source") {
+            finalCmd += "# Follow instructions at this URL to build openvino from source: https://github.com/openvinotoolkit/openvino/blob/master/docs/dev/build.md" + "<br>" ;
+            tcUsage += importCmdOV;
+        }
+        else if (opts.pm == "conda") {
+            tcUsage += importCmdOV;
+        }
+        if (opts.os == "windows" && !tcUsage.includes(importCmdOV)) {
+            tcUsage += importCmdOV;
+        }
+    }
+    if (backend == "onnxrt") {
+        tcUsage += importCmdOnnx;
+        if (opts.pm == "libtorch") {
+            return "# Torch compile onnxruntime not supported with Libtorch";
+        }
+        if (opts.pm == "source") {
+            finalCmd += "# Follow instructions at this URL to build onnxruntime from source: https://onnxruntime.ai/docs/build" + "<br>" ;
+        }
+    }
+    return finalCmd + tcUsage + backendCmd;
+}
+// Add Torch Compile usage instructions as a command note
+function addTorchCompileCommandNote(selectedOptionId) {
+    console.log(selectedOptionId);
+
+    if (!selectedOptionId) {
+        return;
+    }
+
+    $("#command").append(
+        `<pre> ${getInstallCommand(selectedOptionId)} </pre>`
+    );
+    result = getTorchCompileUsage(selectedOptionId);
+    $("#command").append(
+        `<pre> ${result} </pre>`
+    );
+}
 function selectedOption(option, selection, category) {
+   console.log("Surya Option:", option)
   $(option).removeClass("selected");
   $(selection).addClass("selected");
   opts[category] = selection.id;
@@ -208,7 +302,87 @@ function selectedOption(option, selection, category) {
     changeVersion(opts.ptbuild);
     //make sure unsupported platforms are disabled
     disableUnsupportedPlatforms(opts.os);
+  } else if (category === "torch-compile") {
+    if (selection.id === previousSelection) {
+      $(selection).removeClass("selected");
+      opts[category] = null;
+    }
   }
+  commandMessage(buildMatcher());
+  if (category === "os") {
+    disableUnsupportedPlatforms(opts.os);
+    display(opts.os, 'installation', 'os');
+  }
+  changeAccNoneName(opts.os);
+  addTorchCompileCommandNote(opts['torch-compile'])
+}
+
+function display(selection, id, category) {
+  var container = document.getElementById(id);
+  // Check if there's a container to display the selection
+  if (container === null) {
+    return;
+  }
+  var elements = container.getElementsByClassName(category);
+  for (var i = 0; i < elements.length; i++) {
+    if (elements[i].classList.contains(selection)) {
+      $(elements[i]).addClass("selected");
+    } else {
+      $(elements[i]).removeClass("selected");
+    }
+  }
+}
+
+function buildMatcher() {
+  return (
+    opts.ptbuild.toLowerCase() +
+    "," +
+    opts.pm.toLowerCase() +
+    "," +
+    opts.os.toLowerCase() +
+    "," +
+    opts.cuda.toLowerCase() +
+    "," +
+    opts.language.toLowerCase()
+  );
+}
+
+// Cloud Partners sub-menu toggle listeners
+$("[data-toggle='cloud-dropdown']").on("click", function(e) {
+  if ($(this).hasClass("open")) {
+    $(this).removeClass("open");
+    // If you deselect a current drop-down item, don't display it's info any longer
+    display(null, 'cloud', 'platform');
+  } else {
+    $("[data-toggle='cloud-dropdown'].open").removeClass("open");
+    $(this).addClass("open");
+    var cls = $(this).find(".cloud-option-body")[0].className;
+    for (var i = 0; i < supportedCloudPlatforms.length; i++) {
+      if (cls.includes(supportedCloudPlatforms[i])) {
+        display(supportedCloudPlatforms[i], 'cloud', 'platform');
+      }
+    }
+  }
+});
+
+function commandMessage(key) {
+  var object = {"preview,pip,linux,accnone,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "preview,pip,linux,cuda.x,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118", "preview,pip,linux,cuda.y,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121", "preview,pip,linux,cuda.z,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124", "preview,pip,linux,rocm5.x,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2", "preview,conda,linux,cuda.x,python": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia", "preview,conda,linux,cuda.y,python": "conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch-nightly -c nvidia", "preview,conda,linux,cuda.z,python": "conda install pytorch torchvision torchaudio pytorch-cuda=12.4 -c pytorch-nightly -c nvidia", "preview,conda,linux,rocm5.x,python": "<b>NOTE:</b> Conda packages are not currently available for ROCm, please use pip instead<br />", "preview,conda,linux,accnone,python": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly", "preview,libtorch,linux,accnone,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-shared-with-deps-latest.zip</a>", "preview,libtorch,linux,cuda.x,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu118/libtorch-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu118/libtorch-shared-with-deps-latest.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu118/libtorch-cxx11-abi-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu118/libtorch-cxx11-abi-shared-with-deps-latest.zip</a>", "preview,libtorch,linux,cuda.y,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu121/libtorch-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu121/libtorch-shared-with-deps-latest.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu121/libtorch-cxx11-abi-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu121/libtorch-cxx11-abi-shared-with-deps-latest.zip</a>", "preview,libtorch,linux,cuda.z,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu124/libtorch-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu124/libtorch-shared-with-deps-latest.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu124/libtorch-cxx11-abi-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu124/libtorch-cxx11-abi-shared-with-deps-latest.zip</a>", "preview,libtorch,linux,rocm5.x,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/rocm6.2/libtorch-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/rocm6.2/libtorch-shared-with-deps-latest.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/nightly/rocm6.2/libtorch-cxx11-abi-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/rocm6.2/libtorch-cxx11-abi-shared-with-deps-latest.zip</a>", "preview,pip,macos,cuda.x,python": "# CUDA is not available on MacOS, please use default package<br />pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "preview,pip,macos,cuda.y,python": "# CUDA is not available on MacOS, please use default package<br />pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "preview,pip,macos,cuda.z,python": "# CUDA is not available on MacOS, please use default package<br />pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "preview,pip,macos,rocm5.x,python": "# ROCm is not available on MacOS, please use default package<br />pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "preview,pip,macos,accnone,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "preview,conda,macos,cuda.x,python": "# CUDA is not available on MacOS, please use default package<br />conda install pytorch-nightly::pytorch torchvision torchaudio -c pytorch-nightly", "preview,conda,macos,cuda.y,python": "# CUDA is not available on MacOS, please use default package<br />conda install pytorch-nightly::pytorch torchvision torchaudio -c pytorch-nightly", "preview,conda,macos,cuda.z,python": "# CUDA is not available on MacOS, please use default package<br />conda install pytorch-nightly::pytorch torchvision torchaudio -c pytorch-nightly", "preview,conda,macos,rocm5.x,python": "# ROCm is not available on MacOS, please use default package<br />conda install pytorch-nightly::pytorch torchvision torchaudio -c pytorch-nightly", "preview,conda,macos,accnone,python": "conda install pytorch-nightly::pytorch torchvision torchaudio -c pytorch-nightly", "preview,libtorch,macos,accnone,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip'>https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip</a>", "preview,libtorch,macos,cuda.x,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip'>https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip</a>", "preview,libtorch,macos,cuda.y,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip'>https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip</a>", "preview,libtorch,macos,cuda.z,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip'>https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip</a>", "preview,libtorch,macos,rocm5.x,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip'>https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip</a>", "preview,pip,windows,accnone,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu", "preview,pip,windows,cuda.x,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118", "preview,pip,windows,cuda.y,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121", "preview,pip,windows,cuda.z,python": "pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124", "preview,pip,windows,rocm5.x,python": "<b>NOTE:</b> ROCm is not available on Windows", "preview,conda,windows,cuda.x,python": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia", "preview,conda,windows,cuda.y,python": "conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch-nightly -c nvidia", "preview,conda,windows,cuda.z,python": "conda install pytorch torchvision torchaudio pytorch-cuda=12.4 -c pytorch-nightly -c nvidia", "preview,conda,windows,rocm5.x,python": "<b>NOTE:</b> ROCm is not available on Windows", "preview,conda,windows,accnone,python": "conda install pytorch torchvision torchaudio cpuonly -c pytorch-nightly", "preview,libtorch,windows,accnone,cplusplus": "Download here (Release version):<br /><a href='https://download.pytorch.org/libtorch/nightly/cpu/libtorch-win-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cpu/libtorch-win-shared-with-deps-latest.zip</a><br />Download here (Debug version):<br /><a href='https://download.pytorch.org/libtorch/nightly/cpu/libtorch-win-shared-with-deps-debug-latest.zip'>https://download.pytorch.org/libtorch/nightly/cpu/libtorch-win-shared-with-deps-debug-latest.zip</a>", "preview,libtorch,windows,cuda.x,cplusplus": "Download here (Release version):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu118/libtorch-win-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu118/libtorch-win-shared-with-deps-latest.zip</a><br />Download here (Debug version):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu118/libtorch-win-shared-with-deps-debug-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu118/libtorch-win-shared-with-deps-debug-latest.zip</a>", "preview,libtorch,windows,cuda.y,cplusplus": "Download here (Release version):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu121/libtorch-win-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu121/libtorch-win-shared-with-deps-latest.zip</a><br />Download here (Debug version):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu121/libtorch-win-shared-with-deps-debug-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu121/libtorch-win-shared-with-deps-debug-latest.zip</a>", "preview,libtorch,windows,cuda.z,cplusplus": "Download here (Release version):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu124/libtorch-win-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu124/libtorch-win-shared-with-deps-latest.zip</a><br />Download here (Debug version):<br /><a href='https://download.pytorch.org/libtorch/nightly/cu124/libtorch-win-shared-with-deps-debug-latest.zip'>https://download.pytorch.org/libtorch/nightly/cu124/libtorch-win-shared-with-deps-debug-latest.zip</a>", "preview,libtorch,windows,rocm5.x,cplusplus": "<b>NOTE:</b> ROCm is not available on Windows", "stable,pip,linux,accnone,python": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu", "stable,pip,linux,cuda.x,python": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118", "stable,pip,linux,cuda.y,python": "pip3 install torch torchvision torchaudio", "stable,pip,linux,cuda.z,python": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124", "stable,pip,linux,rocm5.x,python": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.1", "stable,conda,linux,cuda.x,python": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch -c nvidia", "stable,conda,linux,cuda.y,python": "conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia", "stable,conda,linux,cuda.z,python": "conda install pytorch torchvision torchaudio pytorch-cuda=12.4 -c pytorch -c nvidia", "stable,conda,linux,rocm5.x,python": "<b>NOTE:</b> Conda packages are not currently available for ROCm, please use pip instead<br />", "stable,conda,linux,accnone,python": "conda install pytorch torchvision torchaudio cpuonly -c pytorch", "stable,libtorch,linux,accnone,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.4.1%2Bcpu.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.4.1%2Bcpu.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcpu.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcpu.zip</a>", "stable,libtorch,linux,cuda.x,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/cu118/libtorch-shared-with-deps-2.4.1%2Bcu118.zip'>https://download.pytorch.org/libtorch/cu118/libtorch-shared-with-deps-2.4.1%2Bcu118.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcu118.zip'>https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcu118.zip</a>", "stable,libtorch,linux,cuda.y,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/cu121/libtorch-shared-with-deps-2.4.1%2Bcu121.zip'>https://download.pytorch.org/libtorch/cu121/libtorch-shared-with-deps-2.4.1%2Bcu121.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/cu121/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcu121.zip'>https://download.pytorch.org/libtorch/cu121/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcu121.zip</a>", "stable,libtorch,linux,cuda.z,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/cu124/libtorch-shared-with-deps-2.4.1%2Bcu124.zip'>https://download.pytorch.org/libtorch/cu124/libtorch-shared-with-deps-2.4.1%2Bcu124.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/cu124/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcu124.zip'>https://download.pytorch.org/libtorch/cu124/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcu124.zip</a>", "stable,libtorch,linux,rocm5.x,cplusplus": "Download here (Pre-cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/rocm6.1/libtorch-shared-with-deps-2.4.1%2Brocm6.1.zip'>https://download.pytorch.org/libtorch/rocm6.1/libtorch-shared-with-deps-2.4.1%2Brocm6.1.zip</a><br />Download here (cxx11 ABI):<br /><a href='https://download.pytorch.org/libtorch/rocm6.1/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Brocm6.1.zip'>https://download.pytorch.org/libtorch/rocm6.1/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Brocm6.1.zip</a>", "stable,pip,macos,cuda.x,python": "# CUDA is not available on MacOS, please use default package<br />pip3 install torch torchvision torchaudio", "stable,pip,macos,cuda.y,python": "# CUDA is not available on MacOS, please use default package<br />pip3 install torch torchvision torchaudio", "stable,pip,macos,cuda.z,python": "# CUDA is not available on MacOS, please use default package<br />pip3 install torch torchvision torchaudio", "stable,pip,macos,rocm5.x,python": "# ROCm is not available on MacOS, please use default package<br />pip3 install torch torchvision torchaudio", "stable,pip,macos,accnone,python": "pip3 install torch torchvision torchaudio", "stable,conda,macos,cuda.x,python": "# CUDA is not available on MacOS, please use default package<br />conda install pytorch::pytorch torchvision torchaudio -c pytorch", "stable,conda,macos,cuda.y,python": "# CUDA is not available on MacOS, please use default package<br />conda install pytorch::pytorch torchvision torchaudio -c pytorch", "stable,conda,macos,cuda.z,python": "# CUDA is not available on MacOS, please use default package<br />conda install pytorch::pytorch torchvision torchaudio -c pytorch", "stable,conda,macos,rocm5.x,python": "# ROCm is not available on MacOS, please use default package<br />conda install pytorch::pytorch torchvision torchaudio -c pytorch", "stable,conda,macos,accnone,python": "conda install pytorch::pytorch torchvision torchaudio -c pytorch", "stable,libtorch,macos,accnone,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip</a>", "stable,libtorch,macos,cuda.x,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip</a>", "stable,libtorch,macos,cuda.y,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip</a>", "stable,libtorch,macos,cuda.z,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip</a>", "stable,libtorch,macos,rocm5.x,cplusplus": "Download arm64 libtorch here (ROCm and CUDA are not supported):<br /><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.4.1.zip</a>", "stable,pip,windows,accnone,python": "pip3 install torch torchvision torchaudio", "stable,pip,windows,cuda.x,python": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118", "stable,pip,windows,cuda.y,python": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121", "stable,pip,windows,cuda.z,python": "pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124", "stable,pip,windows,rocm5.x,python": "<b>NOTE:</b> ROCm is not available on Windows", "stable,conda,windows,cuda.x,python": "conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch -c nvidia", "stable,conda,windows,cuda.y,python": "conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia", "stable,conda,windows,cuda.z,python": "conda install pytorch torchvision torchaudio pytorch-cuda=12.4 -c pytorch -c nvidia", "stable,conda,windows,rocm5.x,python": "<b>NOTE:</b> ROCm is not available on Windows", "stable,conda,windows,accnone,python": "conda install pytorch torchvision torchaudio cpuonly -c pytorch", "stable,libtorch,windows,accnone,cplusplus": "Download here (Release version):<br /><a href='https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.4.1%2Bcpu.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.4.1%2Bcpu.zip</a><br />Download here (Debug version):<br /><a href='https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-debug-2.4.1%2Bcpu.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-debug-2.4.1%2Bcpu.zip</a>", "stable,libtorch,windows,cuda.x,cplusplus": "Download here (Release version):<br /><a href='https://download.pytorch.org/libtorch/cu118/libtorch-win-shared-with-deps-2.4.1%2Bcu118.zip'>https://download.pytorch.org/libtorch/cu118/libtorch-win-shared-with-deps-2.4.1%2Bcu118.zip</a><br />Download here (Debug version):<br /><a href='https://download.pytorch.org/libtorch/cu118/libtorch-win-shared-with-deps-debug-2.4.1%2Bcu118.zip'>https://download.pytorch.org/libtorch/cu118/libtorch-win-shared-with-deps-debug-2.4.1%2Bcu118.zip</a>", "stable,libtorch,windows,cuda.y,cplusplus": "Download here (Release version):<br /><a href='https://download.pytorch.org/libtorch/cu121/libtorch-win-shared-with-deps-2.4.1%2Bcu121.zip'>https://download.pytorch.org/libtorch/cu121/libtorch-win-shared-with-deps-2.4.1%2Bcu121.zip</a><br />Download here (Debug version):<br /><a href='https://download.pytorch.org/libtorch/cu121/libtorch-win-shared-with-deps-debug-2.4.1%2Bcu121.zip'>https://download.pytorch.org/libtorch/cu121/libtorch-win-shared-with-deps-debug-2.4.1%2Bcu121.zip</a>", "stable,libtorch,windows,cuda.z,cplusplus": "Download here (Release version):<br /><a href='https://download.pytorch.org/libtorch/cu124/libtorch-win-shared-with-deps-2.4.1%2Bcu124.zip'>https://download.pytorch.org/libtorch/cu124/libtorch-win-shared-with-deps-2.4.1%2Bcu124.zip</a><br />Download here (Debug version):<br /><a href='https://download.pytorch.org/libtorch/cu124/libtorch-win-shared-with-deps-debug-2.4.1%2Bcu124.zip'>https://download.pytorch.org/libtorch/cu124/libtorch-win-shared-with-deps-debug-2.4.1%2Bcu124.zip</a>", "stable,libtorch,windows,rocm5.x,cplusplus": "<b>NOTE:</b> ROCm is not available on Windows"};
+
+  if (!object.hasOwnProperty(key)) {
+    $("#command").html(
+      "<pre> # Follow instructions at this URL: https://github.com/pytorch/pytorch#from-source </pre>"
+    );
+  } else if (key.indexOf("lts") == 0  && key.indexOf('rocm') < 0) {
+    $("#command").html("<pre>" + object[key] + "</pre>");
+  } else {
+    $("#command").html("<pre>" + object[key] + "</pre>");
+  }
+}
+
+// Set cuda version right away
+changeVersion("stable")
+
+
   commandMessage(buildMatcher());
   if (category === "os") {
     disableUnsupportedPlatforms(opts.os);

--- a/_includes/quick_start_local.html
+++ b/_includes/quick_start_local.html
@@ -103,6 +103,29 @@
         <div class="option-text">CPU</div>
       </div>
     </div>
+    <div class="row compile">
+        <div class="col-md-12 title-block mobile-heading">
+          <div class="option-text">Torch Compile</div>
+        </div>
+        <div class="col-md-2 option block version" id="cuda.x">
+          <div class="option-text">Inductor</div>
+        </div>
+        <div class="col-md-2 option block version" id="cuda.y">
+          <div class="option-text">CUDA graphs</div>
+        </div>
+        <div class="col-md-2 option block version" id="cuda.z">
+          <div class="option-text">ONNX Runtime</div>
+        </div>
+        <div class="col-md-3 option block version" id="rocm5.x">
+          <div class="option-text">OpenVINO</div>
+        </div>
+        <div class="col-md-3 option block version" id="accnone">
+          <div class="option-text">TensorRT</div>
+        </div>
+        <div class="col-md-3 option block version" id="accnone">
+          <div class="option-text">TVM</div>
+        </div>
+      </div>
     <div class="row">
       <div class="col-md-12 title-block command-mobile-heading">
         <div class="option-text">Run this Command:</div>

--- a/_includes/quick_start_local.html
+++ b/_includes/quick_start_local.html
@@ -125,7 +125,7 @@
         <div class="col-md-3 option block version" id="accnone">
           <div class="option-text">TVM</div>
         </div>
-      </div>
+    </div>
     <div class="row">
       <div class="col-md-12 title-block command-mobile-heading">
         <div class="option-text">Run this Command:</div>

--- a/_includes/quick_start_local.html
+++ b/_includes/quick_start_local.html
@@ -124,7 +124,7 @@
         <div class="col-md-2 option block version" id="onnxrt">
           <div class="option-text">ONNX Runtime</div>
         </div>
-        <div class="col-md-3 option block version" id="tensorrt">
+        <div class="col-md-2 option block version" id="tensorrt">
           <div class="option-text">TensorRT</div>
         </div>
         <div class="col-md-2 option block version" id="tvm">

--- a/_includes/quick_start_local.html
+++ b/_includes/quick_start_local.html
@@ -24,6 +24,9 @@
     <div class="col-md-12 title-block">
       <div class="option-text">Compute Platform</div>
     </div>
+    <div class="col-md-12 title-block">
+      <div class="option-text">Torch Compile</div>
+    </div>
     <div class="col-md-12 title-block command-block">
       <div class="option-text command-text">Run this Command:</div>
     </div>
@@ -107,22 +110,19 @@
         <div class="col-md-12 title-block mobile-heading">
           <div class="option-text">Torch Compile</div>
         </div>
-        <div class="col-md-2 option block version" id="cuda.x">
+        <div class="col-md-2 option block version selected" id="inductor">
           <div class="option-text">Inductor</div>
         </div>
-        <div class="col-md-2 option block version" id="cuda.y">
-          <div class="option-text">CUDA graphs</div>
+        <div class="col-md-3 option block" id="cgraphs">
+          <div class="option-text">CUDA Graphs</div>
         </div>
-        <div class="col-md-2 option block version" id="cuda.z">
-          <div class="option-text">ONNX Runtime</div>
-        </div>
-        <div class="col-md-3 option block version" id="rocm5.x">
+        <div class="col-md-2 option block" id="openvino">
           <div class="option-text">OpenVINO</div>
         </div>
-        <div class="col-md-3 option block version" id="accnone">
+        <div class="col-md-3 option block" id="tensorrt">
           <div class="option-text">TensorRT</div>
         </div>
-        <div class="col-md-3 option block version" id="accnone">
+        <div class="col-md-2 option block" id="tvm">
           <div class="option-text">TVM</div>
         </div>
     </div>

--- a/_includes/quick_start_local.html
+++ b/_includes/quick_start_local.html
@@ -106,23 +106,28 @@
         <div class="option-text">CPU</div>
       </div>
     </div>
-    <div class="row compile">
+    <div class="row torch-compile">
+        <!-- Section Label -->
         <div class="col-md-12 title-block mobile-heading">
           <div class="option-text">Torch Compile</div>
         </div>
-        <div class="col-md-2 option block version selected" id="inductor">
+        <!-- Section Label -->
+        <div class="col-md-2 option block version" id="inductor">
           <div class="option-text">Inductor</div>
         </div>
-        <div class="col-md-3 option block" id="cgraphs">
+        <div class="col-md-2 option block version" id="cgraphs">
           <div class="option-text">CUDA Graphs</div>
         </div>
-        <div class="col-md-2 option block" id="openvino">
+        <div class="col-md-2 option block version" id="openvino">
           <div class="option-text">OpenVINO</div>
         </div>
-        <div class="col-md-3 option block" id="tensorrt">
+        <div class="col-md-2 option block version" id="onnxrt">
+          <div class="option-text">ONNX Runtime</div>
+        </div>
+        <div class="col-md-3 option block version" id="tensorrt">
           <div class="option-text">TensorRT</div>
         </div>
-        <div class="col-md-2 option block" id="tvm">
+        <div class="col-md-2 option block version" id="tvm">
           <div class="option-text">TVM</div>
         </div>
     </div>

--- a/assets/quick-start-module.js
+++ b/assets/quick-start-module.js
@@ -182,72 +182,88 @@ function getIDFromBackend(backend) {
       tensorrt: 'tensorrt',
       tvm: 'tvm',
     };
-    return idTobackendMap[backend]
+    return idTobackendMap[backend];
+}
+
+function getPmCmd(backend) {
+    const pmCmd = {
+        onnxrt: 'onnxruntime',
+        tvm: 'apache-tvm',
+        openvino: 'openvino',
+        tensorrt: 'torch-tensorrt',
+    };
+    return pmCmd[backend];
+}
+
+function getImportCmd(backend) {
+    const importCmd = {
+        onnxrt: 'import onnxruntime',
+        tvm: 'import tvm',
+        openvino: 'import openvino.torch',
+        tensorrt: 'import torch_tensorrt'
+    }
+    return importCmd[backend];
 }
 
 function getInstallCommand(optionID) {
     backend = getIDFromBackend(optionID);
+    pmCmd = getPmCmd(optionID);
     finalCmd = "";
-    pipCmdOV = "pip3 install openvino";
-    condaCmdOV = "conda install openvino";
-    pipCmdOnnx = "pip3 install onnxruntime"
-    condaCmdOnnx = "conda install onnxruntime";
-    if (backend == "openvino") {
-        if (opts.pm == "pip") {
-            finalCmd = pipCmdOV;
-        }
-        else if (opts.pm == "conda") {
-            finalCmd = condaCmdOV;
-        }
-    }
-    if(backend == "onnxrt") {
-        if (opts.pm == "pip") {
-            finalCmd = pipCmdOnnx;
-        }
-        else if (opts.pm == "conda") {
-            finalCmd = condaCmdOnnx;
-        }
-    }
+   if (opts.pm == "pip") {
+        finalCmd = `pip3 install ${pmCmd}`;
+   }
+   else if (opts.pm == "conda") {
+        finalCmd = `conda install ${pmCmd}`;
+   }
     return finalCmd;
 }
 
 function getTorchCompileUsage(optionId) {
     backend = getIDFromBackend(optionId);
-    importCmdOV = "<br>" + "import openvino.torch" + "<br>";
+    importCmd = "<br>" + getImportCmd(optionId) + "<br>";
     finalCmd = "";
     tcUsage = "# Torch Compile usage: ";
     backendCmd = `torch.compile(model, backend="${backend}")`;
-    finalUsageCmd = tcUsage;
-    importCmdOnnx = "<br>" + "import onnxruntime" + "<br>";
+    libtorchCmd = `# Torch compile ${backend} not supported with Libtorch`;
+
+    if (opts.pm == "libtorch") {
+        return libtorchCmd;
+    }
     if (backend == "openvino") {
-        if (opts.pm == "libtorch") {
-            return "# Torch compile openvino not supported with Libtorch";
-        }
         if (opts.pm == "source") {
             finalCmd += "# Follow instructions at this URL to build openvino from source: https://github.com/openvinotoolkit/openvino/blob/master/docs/dev/build.md" + "<br>" ;
-            tcUsage += importCmdOV;
+            tcUsage += importCmd;
         }
         else if (opts.pm == "conda") {
-            tcUsage += importCmdOV;
+            tcUsage += importCmd;
         }
-        if (opts.os == "windows" && !tcUsage.includes(importCmdOV)) {
-            tcUsage += importCmdOV;
+        if (opts.os == "windows" && !tcUsage.includes(importCmd)) {
+            tcUsage += importCmd;
         }
     }
+    else{
+        tcUsage += importCmd;
+    }
     if (backend == "onnxrt") {
-        tcUsage += importCmdOnnx;
-        if (opts.pm == "libtorch") {
-            return "# Torch compile onnxruntime not supported with Libtorch";
-        }
         if (opts.pm == "source") {
             finalCmd += "# Follow instructions at this URL to build onnxruntime from source: https://onnxruntime.ai/docs/build" + "<br>" ;
         }
     }
-    return finalCmd + tcUsage + backendCmd;
+    if (backend == "tvm") {
+        if (opts.pm == "source") {
+            finalCmd += "# Follow instructions at this URL to build tvm from source: https://tvm.apache.org/docs/install/from_source.html" + "<br>" ;
+        }
+    }
+    if (backend == "tensorrt") {
+        if (opts.pm == "source") {
+            finalCmd += "# Follow instructions at this URL to build tensorrt from source: https://pytorch.org/TensorRT/getting_started/installation.html#compiling-from-source" + "<br>" ;
+        }
+    }
+    finalCmd += tcUsage + backendCmd;
+    return finalCmd
 }
 // Add Torch Compile usage instructions as a command note
 function addTorchCompileCommandNote(selectedOptionId) {
-    console.log(selectedOptionId);
 
     if (!selectedOptionId) {
         return;
@@ -263,8 +279,6 @@ function addTorchCompileCommandNote(selectedOptionId) {
 
 
 function selectedOption(option, selection, category) {
-  console.log("Surya Option:", option)
-  console.log("Surya prevSel:", opts[category])
   $(option).removeClass("selected");
   $(selection).addClass("selected");
   const previousSelection = opts[category];


### PR DESCRIPTION
Proposal to Enhance torch.compile Onboarding by Adding Installation Instructions on the PyTorch Main Page:

Currently, developers looking to use torch.compile with a specific backend must navigate through multiple steps: they first consult the torch.compile documentation, then visit individual backend documentation pages to understand installation requirements. This fragmented process adds unnecessary friction, especially for those just getting started with torch.compile

We propose adding a dedicated torch.compile row to the Install Table on the PyTorch main page. Given the high traffic on this page, this change would streamline the process for developers. By clicking on the desired backend, developers will be provided with a simple, one-click installation command, making it easier for them to get started.